### PR TITLE
Fix command for getting project version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 script:
-  - sh test_examples.sh
+  - ./test_examples.sh

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -2,7 +2,8 @@
 
 mvn install package
 #find current yajco version
-yajco_version=`mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version | grep -v '\['`
+yajco_version=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate \
+                -Dexpression=project.version -q -DforceStdout)
 #clone yajco-examples and execute tests
 git clone --depth=1 https://github.com/kpi-tuke/yajco-examples
 cd yajco-examples

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -7,4 +7,5 @@ yajco_version=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate \
 #clone yajco-examples and execute tests
 git clone --depth=1 https://github.com/kpi-tuke/yajco-examples
 cd yajco-examples
+echo "Use YAJCo version $yajco_version to run tests in yajco-examples"
 mvn verify -Dyajco.version=$yajco_version


### PR DESCRIPTION
The problem was with the grep command trying to extract version from
the output of Maven. When Maven downloaded dependencies, it included
them in the result. Corrected script suppresses all output except of
the version number, so grep is not needed. Solution is based on
the blog post: https://blog.soebes.de/blog/2018/06/09/help-plugin/